### PR TITLE
toString does not get called automatically (in chrome) when passing messages to/from webworkers

### DIFF
--- a/src/jsandbox-worker.js
+++ b/src/jsandbox-worker.js
@@ -30,16 +30,11 @@
 	var
 	jsonParse         = JSON.parse,
 	jsonStringify     = JSON.stringify,
-	jsonStringifyThis = function () {
-		return jsonStringify.call(JSON, this);
-	},
 	messageEventType  = "message",
 	
 	messageHandler = function (event) {
 		var request = event.data,
-		response = {
-			toString : jsonStringifyThis
-		};
+		response = {};
 		
 		if (typeof request === "string") { // parse JSON
 			request = jsonParse.call(JSON, request);
@@ -72,7 +67,7 @@
 		delete self.input;
 		delete self.onmessage; // in case the code defined it
 		
-		postMessage(response);
+		postMessage(jsonStringify(response));
 	};
 	
 	if (self.addEventListener) {

--- a/src/jsandbox.js
+++ b/src/jsandbox.js
@@ -31,10 +31,7 @@ var JSandbox = (function (self) {
 	var
 	jsonParse         = JSON.parse,
 	jsonStringify     = JSON.stringify,
-	jsonStringifyThis = function () {
-		return jsonStringify.call(JSON, this);
-	},
-	
+  
 	// repeatedly used properties/strings (for minification)
 	$eval       = "eval",
 	$exec       = "exec",
@@ -128,13 +125,12 @@ var JSandbox = (function (self) {
 			
 			this[$requests][id] = options;
 			
-			this[$worker].postMessage({
+			this[$worker].postMessage(jsonStringify({
 				id       : id,
 				method   : method,
 				data     : data,
-				input    : input,
-				toString : jsonStringifyThis
-			});
+				input    : input
+			}));
 		
 			return id;
 		};


### PR DESCRIPTION
Hi, in my version of Chrome 16.0.899.0 dev the javascript engine does not appear to call 'toString' on the json object being posted to a webworker...

Would stringifying the object manually like this work ok for you? 

PS Didn't include minified source, not sure which app you prefer to use for minification.
