### PR TITLE
var after comma

### DIFF
--- a/src/jsandbox-worker.js
+++ b/src/jsandbox-worker.js
@@ -21,8 +21,6 @@
 	var
 	postMessage   = self.postMessage,
 	importScripts = self.importScripts,
-	
-	var
 	messageEventType  = "message",
 	
 	messageHandler = function (event) {


### PR DESCRIPTION
There was a var after importScripts' , which is an syntax error, removed it
